### PR TITLE
10 9 23 image downloader fixed

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1315,11 +1315,12 @@ packages:
   image_downloader:
     dependency: "direct main"
     description:
-      name: image_downloader
-      sha256: "2b1c1d1fcfb6677175d009af3fc86914aee07684c12ea061f380ef1f44cae8df"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.31.0"
+      path: "."
+      ref: HEAD
+      resolved-ref: "9565dbc5c83e013bce2af4daef2616133ae16254"
+      url: "https://github.com/ko2ic/image_downloader.git"
+    source: git
+    version: "0.32.0"
   image_gallery_saver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,7 +55,9 @@ dependencies:
   google_sign_in: 6.1.4
   group_radio_button: 1.3.0
   hydrated_bloc: 9.1.2
-  image_downloader: 0.31.0
+  image_downloader:  # 0.31.0
+    git:
+      url: https://github.com/ko2ic/image_downloader.git
   image_picker: 1.0.2
   intl: 0.18.1
   json_annotation: 4.8.1


### PR DESCRIPTION
Fixed the image downloader by changing pubspec yaml to pull from the github rather than the version number.  No idea why they haven't updated the version by now, but it's done.